### PR TITLE
Input: synaptics-rmi4 - Enable support for F3A by default.

### DIFF
--- a/drivers/hid/Kconfig
+++ b/drivers/hid/Kconfig
@@ -1082,6 +1082,7 @@ config HID_RMI
 	select RMI4_F11
 	select RMI4_F12
 	select RMI4_F30
+        select RMI4_F3A
 	help
 	Support for Synaptics RMI4 touchpads.
 	Say Y here if you have a Synaptics RMI4 touchpads over i2c-hid or usbhid


### PR DESCRIPTION
RMI4 F3A supports the touchpad GPIO function, it's designed to support more GPIOs and used on new touchpad. This patch will enable support of touchpad button.